### PR TITLE
Update repo for Scientific Agent Skills rename and current dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/K-Dense-AI/karpathy/pulls)
 
-An agentic Machine Learning Engineer that trains state-of-the-art ML models using Claude Code SDK and Google ADK. This is a very simple implemenation demonstraing the power of Claude Scientific Skills for machine learning.
+An agentic Machine Learning Engineer that trains state-of-the-art ML models using the Claude Agent SDK and Google ADK. This is a simple implementation demonstrating the power of Scientific Agent Skills for machine learning.
 
 ## Prerequisites
 
 - Python 3.13 or higher
 - [uv](https://github.com/astral-sh/uv) package manager
-- Claude Code installed and authenticated (see [installation guide](https://www.claude.com/product/claude-code))
+- Claude Code installed and authenticated (see the [Claude Code documentation](https://docs.claude.com/en/docs/claude-code/overview))
 
 ## Setup
 
@@ -52,7 +52,7 @@ python start.py
 ```
 
 This automatically:
-1. Creates a `sandbox` directory with scientific skills from Claude Scientific Skills
+1. Creates a `sandbox` directory with skills from Scientific Agent Skills
 2. Sets up a Python virtual environment with ML packages (PyTorch, transformers, scikit-learn, etc.)
 3. Copies your `.env` file to the sandbox
 4. Starts the ADK web interface
@@ -68,9 +68,9 @@ Join our K-Dense Slack community to connect with other users, share ideas, and g
 
 **[Join K-Dense Slack Community](https://join.slack.com/t/k-densecommunity/shared_invite/zt-3iajtyls1-EwmkwIZk0g_o74311Tkf5g)**
 
-## Claude Scientific Skills
+## Scientific Agent Skills
 
-This repository is designed to work with the **[Claude Scientific Skills](https://github.com/K-Dense-AI/claude-scientific-skills)** collection of ready-to-use scientific tools and workflows ([link](https://github.com/K-Dense-AI/claude-scientific-skills)). The `start.py` setup script creates a `sandbox` that includes scientific skills from this collection so the `karpathy` agent can leverage specialized ML libraries and scientific workflows. For full details on the skills themselves, see the upstream repository’s README and documentation [here](https://github.com/K-Dense-AI/claude-scientific-skills).
+This repository is designed to work with **[Scientific Agent Skills](https://github.com/K-Dense-AI/scientific-agent-skills)** (formerly Claude Scientific Skills), a collection of 130+ ready-to-use Agent Skills for research, science, engineering, analysis, finance, and writing built on the open Agent Skills standard. The `start.py` setup script creates a `sandbox` that includes skills from this collection so the `karpathy` agent can leverage specialized ML libraries and scientific workflows. For full details on the skills themselves, see the upstream repository's README and documentation [here](https://github.com/K-Dense-AI/scientific-agent-skills).
 
 ## Manual Usage
 
@@ -92,7 +92,7 @@ Then navigate to **http://localhost:8000** in your browser.
 
 ## Enhanced ML Capabilities
 
-If you want substantially more powerful ML capabilities through a multi-agentic system, sign up for [www.k-dense.ai](https://www.k-dense.ai). Currently in closed beta, launching publicly in December 2025.
+If you want substantially more powerful ML capabilities through a multi-agentic system, sign up for [www.k-dense.ai](https://www.k-dense.ai).
 
 ## Upcoming Features
 

--- a/karpathy/utils.py
+++ b/karpathy/utils.py
@@ -17,14 +17,14 @@ def load_instructions(agent_name: str) -> str:
 
 def download_scientific_skills(
     target_dir: str = "sandbox/.claude/skills",
-    github_repo: str = "K-Dense-AI/claude-scientific-skills",
+    github_repo: str = "K-Dense-AI/scientific-agent-skills",
     source_path: str = "scientific-skills",
     branch: str = "main"
 ) -> None:
     """
     Download all directories from the scientific-skills folder in the GitHub repository
     and place them in the target directory using git clone.
-    
+
     Args:
         target_dir: Local directory to save the skills to
         github_repo: GitHub repository in format "owner/repo"
@@ -41,7 +41,7 @@ def download_scientific_skills(
         
         try:
             # Clone the repository with depth 1 for faster download
-            print("Cloning Claude Scientific Skills repository (this may take a moment)...")
+            print("Cloning Scientific Agent Skills repository (this may take a moment)...")
             subprocess.run(
                 ["git", "clone", "--depth", "1", "--branch", branch, repo_url, str(temp_path)],
                 check=True,
@@ -72,7 +72,7 @@ def download_scientific_skills(
                     print(f"  [+] {skill_dir.name}")
                     skill_count += 1
             
-            print(f"\nSuccessfully downloaded {skill_count} scientific skills to {target_path.absolute()}")
+            print(f"\nSuccessfully downloaded {skill_count} scientific agent skills to {target_path.absolute()}")
             
         except subprocess.CalledProcessError as e:
             print(f"Error cloning repository: {e.stderr}")
@@ -190,8 +190,8 @@ def setup_sandbox() -> None:
     # Copy .env file from karpathy to sandbox
     copy_env_file()
     
-    # Download scientific skills
-    print("\nSetting up scientific skills...")
+    # Download scientific agent skills
+    print("\nSetting up scientific agent skills...")
     download_scientific_skills(target_dir="sandbox/.claude/skills")
     
     # Create uv virtual environment and install ML packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ description = "Karpathy: An agentic Machine Learning Engineer"
 readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
-    "claude-agent-sdk>=0.1.6",
-    "google-adk>=1.18.0",
-    "litellm>=1.79.3",
-    "markitdown[all]>=0.1.3",
-    "mcp>=1.21.1",
-    "modal>=1.2.2",
-    "openai>=2.8.0",
-    "pydantic>=2.12.4",
-    "python-dotenv>=1.2.1",
+    "claude-agent-sdk>=0.1.68",
+    "google-adk>=1.31.1",
+    "litellm>=1.83.13",
+    "markitdown[all]>=0.1.5",
+    "mcp>=1.27.0",
+    "modal>=1.3.3",
+    "openai>=2.32.0",
+    "pydantic>=2.13.3",
+    "python-dotenv>=1.2.2",
 ]


### PR DESCRIPTION
- Rename Claude Scientific Skills to Scientific Agent Skills (new repo:
  K-Dense-AI/scientific-agent-skills) in README, utils.py, and print messages
- Fix README: correct "Claude Code SDK" to "Claude Agent SDK", fix typos,
  update Claude Code link to current docs URL, drop stale launch date
- Bump dependency floors in pyproject.toml to latest published versions
  (claude-agent-sdk 0.1.68, google-adk 1.31.1, litellm 1.83.13, mcp 1.27.0,
  modal 1.3.3, openai 2.32.0, pydantic 2.13.3, markitdown 0.1.5,
  python-dotenv 1.2.2); litellm floor also clears the 1.82.7/1.82.8
  supply-chain advisory